### PR TITLE
Replace stock Claude workflows with customized versions + .claude commands

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -1,0 +1,2 @@
+settings.local.json
+*.local.json

--- a/.claude/commands/check.md
+++ b/.claude/commands/check.md
@@ -1,0 +1,10 @@
+---
+description: Run the R package check suite and report ERRORs/WARNINGs/NOTEs
+allowed-tools:
+  - Bash(Rscript -e 'devtools::check*')
+---
+
+Run `Rscript -e 'devtools::check()'` to run the full R package check suite.
+
+Report any ERRORs, WARNINGs, or NOTEs grouped by severity. For each issue explain
+what it means and suggest a fix. If the check passes cleanly, say so.

--- a/.claude/commands/document.md
+++ b/.claude/commands/document.md
@@ -1,0 +1,16 @@
+---
+description: Regenerate roxygen2 docs and NAMESPACE, then report what changed
+allowed-tools:
+  - Bash(Rscript -e 'devtools::document*')
+  - Bash(git status:*)
+  - Bash(git diff:*)
+---
+
+Run `Rscript -e 'devtools::document()'` to regenerate `man/*.Rd` and `NAMESPACE`
+from the roxygen2 comments.
+
+Then report which generated files changed (`git status` / `git diff`). Flag any
+unexpected diff — e.g. a `man/*.Rd` or `NAMESPACE` change with no corresponding
+roxygen edit, which usually means a generated file was hand-edited or the docs
+were stale. Do not edit `man/*.Rd` or `NAMESPACE` by hand; change the roxygen
+comments and re-run this command.

--- a/.claude/commands/lint.md
+++ b/.claude/commands/lint.md
@@ -1,0 +1,16 @@
+---
+description: Lint all R source files and report issues
+allowed-tools:
+  - Bash(Rscript -e 'lintr::lint*')
+---
+
+Run `Rscript -e 'lintr::lint_package()'` to check all R source files against
+`.lintr.R` (this is what CI runs).
+
+Report all lint issues grouped by file, including:
+
+- File path and line number
+- The lint rule violated
+- A one-line explanation of how to fix it
+
+If there are no issues, confirm the code is clean.

--- a/.claude/commands/test.md
+++ b/.claude/commands/test.md
@@ -1,0 +1,17 @@
+---
+description: Run the testthat suite and report failures
+allowed-tools:
+  - Bash(Rscript -e 'devtools::test*')
+---
+
+Run `Rscript -e 'devtools::test()'` to run the full testthat suite.
+
+Report any failing or warning tests, grouped by test file, including:
+
+- The test description and file
+- The expectation that failed and the observed vs. expected value
+- A one-line suggestion for the likely cause
+
+For snapshot/`vdiffr` failures, note whether the change looks intentional (a
+deliberate plot change needing a snapshot update) or a regression. If everything
+passes, say so and report the test count.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": [
+      "Bash(Rscript -e 'devtools::check*')",
+      "Bash(Rscript -e 'devtools::test*')",
+      "Bash(Rscript -e 'devtools::document*')",
+      "Bash(Rscript -e 'devtools::load_all*')",
+      "Bash(Rscript -e 'roxygen2::roxygenise*')",
+      "Bash(Rscript -e 'lintr::lint*')",
+      "Bash(Rscript -e 'spelling::spell_check_package*')",
+      "Bash(Rscript -e 'pkgdown::build*')",
+      "Bash(Rscript -e 'covr::package_coverage*')",
+      "Bash(R CMD check:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git status)",
+      "Bash(git show:*)",
+      "Bash(git add:*)",
+      "Bash(git commit -m:*)",
+      "Bash(git switch:*)",
+      "Bash(git branch:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr diff:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh pr create:*)",
+      "Bash(gh pr edit:*)",
+      "Bash(gh issue view:*)",
+      "Bash(gh issue list:*)",
+      "Bash(gh run view:*)",
+      "Bash(gh run list:*)"
+    ],
+    "deny": [
+      "Bash(git push --force:*)",
+      "Bash(git push -f:*)",
+      "Bash(git commit --amend:*)",
+      "Bash(git commit --no-verify:*)",
+      "Bash(git branch -d:*)",
+      "Bash(git branch -D:*)",
+      "Bash(git reset --hard:*)",
+      "Bash(rm -rf:*)"
+    ]
+  }
+}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,29 +1,70 @@
+# Automatic Claude Code review of pull requests.
+#
+# Runs the upstream `code-review@claude-code-plugins` plugin so we pick up
+# any improvements to the canonical review skill, then layers an
+# R-package-specific addendum on top so the reviewer also catches issues
+# particular to this package.
+#
+# Each run posts a fresh review comment; prior reviews are left in place
+# so the PR keeps a visible history rather than a rolling sticky.
+#
+# Skips drafts, Dependabot bumps, and fork PRs (fork PRs can't read repo
+# secrets). Project guidance is in CLAUDE.md (if present). Requires the
+# CLAUDE_CODE_OAUTH_TOKEN repository secret.
+
 name: Claude Code Review
 
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+  # Allow claude.yml to dispatch a fresh review (e.g. after an @claude run
+  # pushes commits, or on an `@claude review` comment). GITHUB_TOKEN pushes
+  # don't fire `synchronize`, so an explicit dispatch path is needed.
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'Pull request number to review'
+        required: true
+        type: number
+
+# Serialize reviews per PR: a newer push cancels the in-progress review
+# of the now-stale diff so only the freshest review runs (and posts a
+# comment). `cancel-in-progress: true` is safe here because this workflow
+# is read-only (its allowedTools below grant no git push / commit), so it
+# never pushes a fix and therefore can't trigger self-cancellation. The
+# `|| inputs.pr_number` keeps a workflow_dispatch review in the same group
+# as the PR's pull_request reviews so they dedupe.
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number || inputs.pr_number }}
+  cancel-in-progress: true
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
+    # workflow_dispatch is fired by claude.yml for a specific PR, so always
+    # run it — this intentionally bypasses the draft guard below so a review
+    # fires on the draft PR claude.yml opens for an issue trigger (we want to
+    # review Claude's draft work early). Otherwise skip drafts, Dependabot
+    # bumps, and fork PRs (fork PRs can't read repo secrets, so
+    # CLAUDE_CODE_OAUTH_TOKEN would be empty and the run would fail with a
+    # noisy red check).
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.draft == false &&
+       github.event.pull_request.user.login != 'dependabot[bot]' &&
+       github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
+    env:
+      # Resolve the PR number once: from the pull_request event, or the
+      # workflow_dispatch input when claude.yml triggered us.
+      PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write  # post review + inline comments
       issues: read
-      id-token: write
+      id-token: write       # required by claude-code-action for the App-token
+                            # exchange it performs even with OAuth auth
+                            # (without this, the action fails with
+                            # "App token exchange failed: 401 Unauthorized")
 
     steps:
       - name: Checkout repository
@@ -31,14 +72,65 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Run Claude Code Review
-        id: claude-review
+      - name: Claude PR review
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          # `claude-code-plugins` is a branch name, not a version tag.
+          # Intentionally unpinned so we pick up future improvements to the
+          # upstream code-review skill; pin to a tag if reviews ever start
+          # changing in surprising ways.
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
+          # track_progress forces tag mode (guaranteed tracking comment),
+          # but the action rejects it for workflow_dispatch events
+          # ("track_progress is only supported for events: pull_request,
+          # issues, ..."). Gate on event_name: tag mode for pull_request,
+          # agent mode for dispatched runs.
+          track_progress: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
+          prompt: |
+            /code-review:code-review ${{ github.repository }}/pull/${{ env.PR_NUMBER }}
 
+            In addition to the standard checks above, this is `rwicc`, an R
+            package implementing regression with an interval-censored
+            covariate (Morrison et al. 2021), so also prioritize:
+
+            1. **R correctness**
+               - Statistical / numerical logic matches the methods in the
+                 package's documentation and the cited paper.
+               - No partial argument matching; `if`/`else` branches and
+                 vectorized operations handle edge cases (empty data, NA,
+                 zero-row frames).
+               - New exported functions have complete roxygen2 docs
+                 (`@param`, `@return`, `@examples`) and `@export`.
+
+            2. **Style & lint**
+               - Conforms to `.lintr` settings (snake_case, line length,
+                 object usage). No new lintr violations.
+               - No new package dependencies in DESCRIPTION without
+                 justification; new Imports must be actually used.
+
+            3. **Tests & docs hygiene**
+               - Behavior changes come with testthat tests.
+               - `man/*.Rd` is generated — edits belong in roxygen comments,
+                 then `devtools::document()`; flag hand-edited `.Rd`.
+               - `README.md` is generated from `README.Rmd` if present;
+                 flag direct edits to the `.md`.
+               - User-facing text changes are spell-checked
+                 (`spelling::spell_check_package()`; additions go in
+                 `inst/WORDLIST`).
+
+            4. **Versioning & CI**
+               - Non-trivial changes bump the Version in DESCRIPTION and add
+                 a NEWS.md entry.
+               - Workflow changes don't break R-CMD-check, pkgdown, or
+                 test-coverage pipelines.
+
+            Use inline comments for line-specific feedback. Skip generic
+            praise — be concrete. If the PR looks clean, say so briefly.
+
+          # `gh pr comment` is narrowed to `create` so the reviewer can post
+          # a top-level summary but can't edit or delete prior review
+          # comments (each run leaves a fresh comment; history stays).
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment create:*)"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,3 +1,25 @@
+# Claude Code GitHub Action (agent mode)
+#
+# Responds to "@claude" mentions in issues, issue comments, PR review
+# comments, and PR reviews. Requires the CLAUDE_CODE_OAUTH_TOKEN secret.
+#
+# This workflow runs the action in AGENT mode (a `prompt:` is set below).
+# Agent mode does NOT run the action's built-in branch-setup / git-push /
+# response-comment machinery that tag mode provides, so this workflow
+# reproduces it with explicit pre/post steps:
+#   - "Set up branch for issue trigger" creates claude/issue-N-<ts>.
+#   - "Push branch and open draft PR for issue trigger" pushes it + opens
+#     a draft PR, so an @claude mention on an *issue* yields a PR.
+#   - "Post Claude's response if no code was committed" surfaces prose
+#     replies (questions/reviews) that agent mode would otherwise discard.
+#   - "Dispatch claude-code-review.yml on @claude review" routes review
+#     requests to the dedicated reviewer instead of self-reviewing.
+# Adapted from UCD-SERG/qwt's claude.yml to rwicc's R-package setup
+# (DESCRIPTION-based deps via setup-r-dependencies; no Quarto, no
+# submodules, no renv-token URL rewrite).
+#
+# Project guidance for Claude lives in CLAUDE.md at the repo root (if present).
+
 name: Claude Code
 
 on:
@@ -6,45 +28,380 @@ on:
   pull_request_review_comment:
     types: [created]
   issues:
-    types: [opened, assigned]
+    # `assigned` is intentionally NOT triggered: the actor-gate below checks
+    # `github.event.issue.author_association`, which describes the issue
+    # *author* — not the assigner. A collaborator assigning themselves to an
+    # outsider's issue would fail the gate. If you need a collaborator to
+    # invoke @claude on an outsider's issue, leave a comment instead.
+    types: [opened]
   pull_request_review:
     types: [submitted]
 
+# Serialize @claude sessions per issue/PR so rapid mentions don't fire
+# competing runs that race to push the same branch. `cancel-in-progress:
+# false` queues a new mention behind the running session rather than
+# killing it. `|| github.run_id` is a defensive fallback so an unexpected
+# event with no issue/PR number doesn't collapse the group to `claude-`
+# and serialize every session globally.
+concurrency:
+  group: claude-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: false
+
 jobs:
   claude:
+    # Only trigger for trusted authors (OWNER / MEMBER / COLLABORATOR).
+    # Without this, anyone who can comment on a public issue or PR could
+    # trigger an LLM run with write-scoped GITHUB_TOKEN permissions.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
     runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write       # so Claude can push a branch
+      pull-requests: write  # so Claude can open / edit PRs
+      issues: write         # so Claude can comment on issues
       id-token: write
-      actions: read # Required for Claude to read CI results on PRs
+      actions: write        # read CI results on PRs AND dispatch
+                            # claude-code-review.yml via `gh workflow run`
+                            # (workflow_dispatch needs actions: write — with
+                            # only `read`, the dispatch 403s and the review
+                            # routing silently fails)
+
     steps:
+      # Post a visible acknowledgment BEFORE the multi-minute R setup
+      # begins, so the user knows the @claude mention was received.
+      # `continue-on-error` keeps a transient comment-API hiccup from
+      # failing the whole run. Posted by github-actions[bot], so it does
+      # not re-trigger this workflow (the if: gate keys on `@claude`).
+      - name: Acknowledge @claude mention
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NUM: ${{ github.event.issue.number || github.event.pull_request.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh issue comment "$NUM" --repo "${{ github.repository }}" \
+            --body ":eyes: Picked up by [workflow run #${{ github.run_id }}]($RUN_URL). R setup runs first; Claude itself responds after that."
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: |
+            any::devtools
+            any::roxygen2
+            any::lintr
+            any::spelling
+            any::pkgdown
+            any::rcmdcheck
+          needs: check
+
+      # Record the PR's head SHA before Claude runs (PR triggers only), so
+      # the post-steps can tell whether Claude pushed new commits.
+      - name: Capture PR head SHA before Claude
+        id: head_before
+        if: github.event.pull_request.number || github.event.issue.pull_request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number || github.event.issue.number }}"
+          SHA=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER" --jq '.head.sha')
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+
+      # Create a feature branch for issue triggers so Claude's commits land
+      # somewhere durable. Agent mode skips the action's built-in
+      # setup-branch step, so without this an @claude mention on an issue
+      # would edit files on the ephemeral checkout and lose them at runner
+      # cleanup. The "Push branch and open draft PR" post-step pushes this
+      # branch and opens the PR. Only fires for issue / issue-comment-on-
+      # issue events (PR triggers commit to the PR's own branch).
+      - name: Set up branch for issue trigger
+        id: issue_branch
+        if: |
+          github.event_name == 'issues' ||
+          (github.event_name == 'issue_comment' && !github.event.issue.pull_request)
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          BRANCH="claude/issue-${ISSUE_NUMBER}-$(date -u +%Y%m%d-%H%M%S)"
+          git checkout -b "$BRANCH"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "starting_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "Created and switched to $BRANCH"
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1
+        # GH_TOKEN authenticates the `gh` commands granted in claude_args
+        # (gh pr create/edit/view); without it `gh` prompts and fails in CI.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # This is an optional setting that allows Claude to read CI results on PRs
-          additional_permissions: |
-            actions: read
+          # Setting `prompt:` puts the action in AGENT mode (see header).
+          # The triggering comment/issue body is already supplied to Claude
+          # by the action's default prompt; this only adds the workflow's
+          # own operating instructions.
+          prompt: |
+            You were triggered by an @claude mention in a
+            ${{ github.event_name }} event. Address the request in the
+            triggering comment / issue / review.
 
-          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
+            Git & PR handling (a workflow step does the pushing/PR-opening,
+            not you):
+            - **Issue triggers**: a fresh `claude/issue-N-<timestamp>`
+              branch has already been created and checked out for you. Make
+              your edits and `git commit` them. Do NOT create another branch
+              and do NOT run `gh pr create` — a post-step pushes this branch
+              and opens a draft PR linking back to the issue.
+            - **PR triggers**: commit your changes; they belong on the PR's
+              branch. A post-step dispatches a code review when the head SHA
+              moves.
 
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr *)'
+            Before declaring the task complete, check for additional @claude
+            requests that arrived after the triggering event:
+            1. Fetch the latest comments:
+               `gh api 'repos/${{ github.repository }}/issues/${{ github.event.issue.number || github.event.pull_request.number }}/comments' --paginate`
+            2. Identify comments where ALL hold: created_at strictly after
+               the triggering comment, body contains `@claude`, and
+               user.login is neither `claude[bot]` nor `github-actions[bot]`.
+            3. Address each such comment in this same session (chronological
+               order), then repeat from step 1 until none remain.
+            4. Commit all changes before finishing.
 
+            If your reply is **prose** (answering a question, a
+            recommendation, a review) rather than a code change, write your
+            final message as the reply you want posted on the thread — a
+            post-step posts it as a comment when you didn't commit code.
+
+            For an explicit `@claude review` request, do NOT post your own
+            review; a post-step dispatches the dedicated code-review
+            workflow instead.
+
+          # Allowed git/gh/Rscript commands. `git push` is narrowed to
+          # `origin` and destructive flag/refspec variants are denied so the
+          # write-scoped token can't rewrite or delete refs. `Rscript -e` is
+          # restricted to specific namespaces. The `gh api`/`gh pr/issue
+          # view` reads back the late-comment-polling step above. devtools /
+          # pkgdown run project R code that can `system()`; the real
+          # containment is the trusted-author gate in the job `if:` above.
+          claude_args: |
+            --allowedTools "Bash(Rscript -e 'lintr::lint*'),Bash(Rscript -e 'devtools::check*'),Bash(Rscript -e 'devtools::test*'),Bash(Rscript -e 'devtools::document*'),Bash(Rscript -e 'roxygen2::roxygenise*'),Bash(Rscript -e 'spelling::spell_check_package*'),Bash(Rscript -e 'pkgdown::build*'),Bash(git diff:*),Bash(git log:*),Bash(git status:*),Bash(git show:*),Bash(git checkout:*),Bash(git switch:*),Bash(git branch:*),Bash(git add:*),Bash(git commit:*),Bash(git push origin:*),Bash(git push -u origin:*),Bash(gh api:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr create:*),Bash(gh pr edit:*),Bash(gh issue view:*)" --disallowedTools "Bash(git push --force:*),Bash(git push -f:*),Bash(git push --delete:*),Bash(git push -d:*),Bash(git push --mirror:*),Bash(git push --tags:*),Bash(git push --all:*),Bash(git push origin +*),Bash(git push -u origin +*)"
+
+      # Fetch the PR's head SHA once, post-Claude, for the two steps that
+      # both need it (the prose-post COMMITTED check and the re-request
+      # step). PR-context only; mirrors the before-step above.
+      - name: Capture PR head SHA after Claude
+        id: head_after
+        if: always() && (github.event.pull_request.number || github.event.issue.pull_request)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number || github.event.issue.number }}"
+          SHA=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER" --jq '.head.sha')
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+
+      # Surface Claude's final prose reply when it didn't commit code.
+      # Agent mode discards the response otherwise. Skipped on `@claude
+      # review` (with PR context) because the dispatch step below routes
+      # that to the dedicated reviewer — posting here too would double up.
+      # The PR-context guard keeps `@claude review` on a plain issue from
+      # falling into the skip (no PR to dispatch a review for).
+      - name: Post Claude's response if no code was committed
+        if: |
+          always() &&
+          steps.claude.outcome == 'success' &&
+          !(
+            (
+              contains(github.event.comment.body, '@claude review') ||
+              contains(github.event.review.body, '@claude review')
+            ) &&
+            (github.event.pull_request.number || github.event.issue.pull_request)
+          )
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ENTITY_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          EXECUTION_FILE: ${{ steps.claude.outputs.execution_file }}
+          ISSUE_BRANCH_STARTING_SHA: ${{ steps.issue_branch.outputs.starting_sha }}
+          PR_HEAD_BEFORE: ${{ steps.head_before.outputs.sha }}
+          PR_HEAD_AFTER: ${{ steps.head_after.outputs.sha }}
+        run: |
+          # Did Claude commit anything? Issue triggers: local HEAD vs the
+          # pre-step's recorded tip. PR triggers: PR head SHA before vs
+          # after. Either guard requires a non-empty "after" so a failed
+          # SHA fetch doesn't get misread as "committed" (which would
+          # wrongly suppress the prose post).
+          COMMITTED=false
+          if [ -n "$ISSUE_BRANCH_STARTING_SHA" ]; then
+            [ "$(git rev-parse HEAD)" != "$ISSUE_BRANCH_STARTING_SHA" ] && COMMITTED=true
+          fi
+          if [ -n "$PR_HEAD_BEFORE" ] && [ -n "$PR_HEAD_AFTER" ] && [ "$PR_HEAD_AFTER" != "$PR_HEAD_BEFORE" ]; then
+            COMMITTED=true
+          fi
+          if [ "$COMMITTED" = "true" ]; then
+            echo "Claude committed code; commits are the deliverable, skipping response-text post."
+            exit 0
+          fi
+
+          FILE="${EXECUTION_FILE:-/home/runner/work/_temp/claude-execution-output.json}"
+          if [ ! -f "$FILE" ]; then
+            echo "::warning::No Claude execution output at $FILE; nothing to post."
+            exit 0
+          fi
+
+          # execution_file is a single JSON array of event objects. flatten(1)
+          # collapses the slurp wrap so we iterate event objects whether the
+          # file is one array (real), NDJSON, or has a stray array element;
+          # the type=="object" guard skips non-objects before `.type`.
+          ASSISTANT_COUNT=$(jq -rs 'flatten(1) | [.[] | select(type == "object" and .type == "assistant")] | length' < "$FILE")
+          if [ "$ASSISTANT_COUNT" = "0" ]; then
+            echo "::warning::No assistant-typed events in $FILE — action output schema may have changed. Nothing to post."
+            exit 0
+          fi
+          RESPONSE=$(jq -rs '
+            flatten(1)
+            | [.[] | select(type == "object" and .type == "assistant")]
+            | last
+            | (.message.content // [])
+            | map(select(.type == "text") | .text)
+            | join("\n\n")
+          ' < "$FILE")
+          if [ -z "$RESPONSE" ] || [ "$RESPONSE" = "null" ]; then
+            echo "::warning::Assistant events present but no text content; nothing to post."
+            exit 0
+          fi
+
+          # GitHub comment bodies cap at 65,536 bytes; truncate by bytes
+          # (wc -c / head -c, not bash ${#} which counts characters). Pipe
+          # the byte-cut through `iconv -c` to drop a trailing partial
+          # multibyte char, so head -c can't leave invalid UTF-8 that gh
+          # would reject or render as a replacement glyph.
+          MAX_LEN=60000
+          BYTE_LEN=$(printf '%s' "$RESPONSE" | wc -c)
+          if [ "$BYTE_LEN" -gt "$MAX_LEN" ]; then
+            RESPONSE="$(printf '%s' "$RESPONSE" | head -c "$MAX_LEN" | iconv -f UTF-8 -t UTF-8 -c)
+
+          … (response truncated at ${MAX_LEN} bytes; full text in the [workflow run](${RUN_URL}))"
+          fi
+
+          gh issue comment "$ENTITY_NUMBER" --repo "${{ github.repository }}" --body "$(printf '%s\n\n<sub>— posted by @claude post-step from [workflow run](%s)</sub>\n' "$RESPONSE" "$RUN_URL")" \
+            || echo "::warning::Could not post Claude's response back to the source thread."
+
+      # Route an explicit `@claude review` request to the dedicated reviewer
+      # workflow rather than letting the agent self-review (which would
+      # double up with claude-code-review.yml's own push-triggered run).
+      # No outcome guard: a review dispatch doesn't depend on the agent's
+      # output, so fire it even if the agent step was skipped/cancelled.
+      - name: Dispatch claude-code-review.yml on @claude review comment
+        if: |
+          always() &&
+          (github.event.pull_request.number || github.event.issue.pull_request) &&
+          (
+            contains(github.event.comment.body, '@claude review') ||
+            contains(github.event.review.body, '@claude review')
+          )
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number || github.event.issue.number }}"
+          echo "Dispatching claude-code-review.yml for PR #$PR_NUMBER (@claude review comment)."
+          gh workflow run claude-code-review.yml -f pr_number="$PR_NUMBER" \
+            || echo "::warning::Could not dispatch claude-code-review.yml; review will not auto-run."
+
+      # When Claude pushed new commits to a PR, re-request d-morrison as
+      # reviewer and dispatch a fresh code review on the new diff.
+      # GITHUB_TOKEN-driven pushes don't fire `synchronize`, so the review
+      # workflow wouldn't auto-trigger without this explicit dispatch.
+      - name: Re-request review and dispatch code review if Claude pushed commits
+        if: always() && (github.event.pull_request.number || github.event.issue.pull_request) && steps.head_before.outputs.sha != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHA_BEFORE: ${{ steps.head_before.outputs.sha }}
+          SHA_AFTER: ${{ steps.head_after.outputs.sha }}
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number || github.event.issue.number }}"
+          echo "before=$SHA_BEFORE  after=$SHA_AFTER"
+          if [ -n "$SHA_AFTER" ] && [ "$SHA_AFTER" != "$SHA_BEFORE" ]; then
+            echo "Claude pushed new commits; re-requesting reviewer and dispatching code review."
+            gh api -X POST "repos/${{ github.repository }}/pulls/$PR_NUMBER/requested_reviewers" -f "reviewers[]=d-morrison" \
+              || echo "::warning::Could not re-request d-morrison as reviewer."
+            gh workflow run claude-code-review.yml -f pr_number="$PR_NUMBER" \
+              || echo "::warning::Could not dispatch claude-code-review.yml."
+          else
+            echo "No new commits on PR head; skipping review dispatch."
+          fi
+
+      # Pair to "Set up branch for issue trigger": push the branch Claude
+      # committed to and open a draft PR. Runs on always() so partial work
+      # is preserved even if the Claude step failed. The checkout uses the
+      # persisted GITHUB_TOKEN (no submodule-token URL rewrite), so a plain
+      # `git push origin` authenticates — no token-bearing URL needed.
+      - name: Push branch and open draft PR for issue trigger
+        if: |
+          always() &&
+          steps.issue_branch.outputs.branch != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ steps.issue_branch.outputs.branch }}
+          STARTING_SHA: ${{ steps.issue_branch.outputs.starting_sha }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          CURRENT_SHA=$(git rev-parse HEAD)
+          if [ "$CURRENT_SHA" = "$STARTING_SHA" ]; then
+            echo "No new commits on $BRANCH — Claude produced no changes; skipping push/PR."
+            exit 0
+          fi
+          echo "Pushing $BRANCH ($STARTING_SHA -> $CURRENT_SHA)"
+          git push origin "$BRANCH"
+          EXISTING=$(gh pr list --head "$BRANCH" --state open --json url --jq '.[0].url // empty')
+          if [ -n "$EXISTING" ]; then
+            echo "PR already exists for $BRANCH: $EXISTING"
+            PR_URL="$EXISTING"
+            PR_VERB="pushed new commits to existing draft PR"
+          else
+            # "Addresses #N" (not "Closes/Fixes #N") is deliberate: this is a
+            # draft of Claude's attempt and may not fully resolve the issue,
+            # so we don't want merging it to auto-close the issue. A human can
+            # switch to "Closes" on the PR if the work is in fact complete.
+            PR_BODY=$(printf 'Draft PR opened by `@claude` to address #%s.\n\nTriggered by [workflow run](%s).\n\nAddresses #%s.\n' \
+              "$ISSUE_NUMBER" "$RUN_URL" "$ISSUE_NUMBER")
+            if [ -z "$ISSUE_TITLE" ]; then
+              PR_TITLE="Claude response to issue #${ISSUE_NUMBER}"
+            else
+              PR_TITLE="$ISSUE_TITLE"
+            fi
+            PR_URL=$(gh pr create \
+              --base "${{ github.event.repository.default_branch }}" \
+              --head "$BRANCH" \
+              --draft \
+              --title "$PR_TITLE" \
+              --body "$PR_BODY")
+            echo "Opened draft PR: $PR_URL"
+            PR_VERB="opened draft PR"
+          fi
+          # Dispatch a review on the new commits, for both the freshly-opened
+          # and the already-exists (idempotent re-run) paths. The review's
+          # own concurrency group dedupes a redundant dispatch.
+          gh workflow run claude-code-review.yml -f pr_number="${PR_URL##*/}" \
+            || echo "::warning::Could not dispatch claude-code-review.yml."
+          gh issue comment "$ISSUE_NUMBER" --repo "${{ github.repository }}" \
+            --body "Pushed Claude's commits to \`${BRANCH}\` and ${PR_VERB}: ${PR_URL}" \
+            || echo "::warning::Could not post PR link as issue comment."


### PR DESCRIPTION
## Summary

- Replaces the **stock** `claude.yml` / `claude-code-review.yml` templates (merged to `main` by #27 via install-github-app) with **qwt-derived customized** workflows.
- Adds `.claude/` slash commands (`check`, `lint`, `document`, `test`) and a project permission allow/deny list.

### Agent workflow (`claude.yml`)
- Trusted-author gate (OWNER/MEMBER/COLLABORATOR) — stock version had no author check.
- `write` permissions so Claude can push branches / open PRs (stock was read-only).
- Per-PR/issue concurrency (`cancel-in-progress: false`) to avoid racing pushes.
- Late-comment polling, issue→draft-PR flow, prose-reply posting, and review dispatch on push.
- R-package setup (`setup-pandoc`/`setup-r`/`setup-r-dependencies`) and `Rscript`/`gh` allowlists with destructive `git push` denied.

### Review workflow (`claude-code-review.yml`)
- Upstream `code-review@claude-code-plugins` plugin + R-package review addendum (roxygen/`.Rd`, `.lintr`, DESCRIPTION deps, NEWS/version, testthat).
- `workflow_dispatch` path so the agent workflow can trigger reviews; per-PR concurrency.

Adapted from `UCD-SERG/qwt` for rwicc's R-package layout (no Quarto/submodules). Requires the `CLAUDE_CODE_OAUTH_TOKEN` secret (already set).

## Test plan

- [ ] Confirm both workflows parse / appear under the repo Actions tab after merge.
- [ ] On a follow-up PR, verify the review workflow posts a review.
- [ ] Comment `@claude` to confirm the agent workflow triggers and can push.